### PR TITLE
ci(release): enforce npm provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
 
@@ -32,10 +33,11 @@ jobs:
       - name: Changesets publish
         uses: changesets/action@v1
         with:
-          publish: pnpm -r publish --access public --provenance --no-git-checks
+          publish: pnpm publish --access public --provenance --no-git-checks
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true
 
 


### PR DESCRIPTION
- Use single-package publish (drop -r)
- Keep --provenance and set NPM_CONFIG_PROVENANCE=true
- Ensure id-token: write and NODE_AUTH_TOKEN mapping

Merging will make npm show the provenance panel reliably.